### PR TITLE
Slack filter feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
-# CHROMA_HOST = os.environ.get("SS_CHROMA_DB_HOST") or "127.0.0.1"
-# CHROMA_PORT = os.environ.get("SS_CHROMA_DB_PORT") or 5555
-
-# TOGETHER_MODEL_NAME="togethercomputer/llama-2-70b-chat"
+# SS_CHROMA_DB_HOST="127.0.0.1"
+# SS_CHROMA_DB_PORT=5555
 
 # TOGETHER_MODEL_NAME="togethercomputer/llama-2-70b-chat"
 TOGETHER_API_KEY="----------------"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ environment.py
 
 chroma_db/
 db/
+sqlite/
 temp/
 shelve/
 

--- a/server.py
+++ b/server.py
@@ -1,3 +1,5 @@
+import sys
+sys.path.append('./src')
 from flask import Flask, request, Response
 from flask_cors import CORS
 import threading

--- a/src/semantic_search_engine/constants.py
+++ b/src/semantic_search_engine/constants.py
@@ -1,6 +1,5 @@
 import os
 from dotenv import load_dotenv
-import shelve
 
 load_dotenv()
 
@@ -13,7 +12,7 @@ CHROMA_HOST = os.environ.get("SS_CHROMA_DB_HOST") or "127.0.0.1"
 CHROMA_PORT = os.environ.get("SS_CHROMA_DB_PORT") or 5555
 
 # Slack Sqlite
-SQLITE_PATH = os.path.join(DIR, 'db')
+SQLITE_PATH = os.path.join(DIR, 'sqlite')
 TEMP_SLACK_DATA_PATH = os.path.join(SQLITE_PATH, 'temp/')
 
 # LLM       # TODO: We should use our own instance of a hosted LLM
@@ -38,14 +37,3 @@ FETCH_INTERVAL_SHELVE = os.path.join(SHELVE_PATH, "fetch_interval")
 MM_PAT_SHELVE = os.path.join(SHELVE_PATH, "personal_access_token")
 MM_API_URL_SHELVE = os.path.join(SHELVE_PATH, "mattermost_api_url")
 CHROMA_N_RESULTS_SHELVE = os.path.join(SHELVE_PATH, "chroma_n_results")
-# SETTINGS_SHELVE = os.path.join(SHELVE_PATH, "settings")
-
-# # Constants from shelve
-# with shelve.open(SETTINGS_SHELVE_NAME) as settings:
-#     MM_API_URL = settings['mattermost_api_url']
-
-#     CHROMA_N_RESULTS = settings['chroma_n_results']
-
-#     # TODO: This should be kept more securely
-#     MM_PERSONAL_ACCESS_TOKEN = settings['personal_access_token']
-

--- a/src/semantic_search_engine/constants.py
+++ b/src/semantic_search_engine/constants.py
@@ -30,7 +30,7 @@ DEFAULT_CHROMA_N_RESULTS = 25
 
 # Shelve
 SHELVE_PATH = os.path.join(DIR, 'shelve')
-SHELVE_FIELD = 'value'
+# SHELVE_FIELD = 'value'
 
 LAST_FETCH_TIME_SHELVE = os.path.join(SHELVE_PATH, "last_fetch_time")
 FETCH_INTERVAL_SHELVE = os.path.join(SHELVE_PATH, "fetch_interval")

--- a/src/semantic_search_engine/mattermost/__init__.py
+++ b/src/semantic_search_engine/mattermost/__init__.py
@@ -2,10 +2,10 @@ import shelve
 import os
 from semantic_search_engine.constants import *
 
-def __set_default_shelve(shelve_name: str, field_name: str, default_value):
+def __set_default_shelve(shelve_name: str, default_value):
     with shelve.open( shelve_name ) as fetch_interval:
-        if not fetch_interval.get( field_name, False ):
-            fetch_interval[ field_name ] = default_value
+        if not fetch_interval.get( shelve_name, False ):
+            fetch_interval[ shelve_name ] = default_value
 
 # Create the shelve directory if it doesn't exist
 os.makedirs(SHELVE_PATH, exist_ok=True)
@@ -15,20 +15,17 @@ os.makedirs(SHELVE_PATH, exist_ok=True)
 # Default fetch_interval
 __set_default_shelve(
     shelve_name=FETCH_INTERVAL_SHELVE,
-    field_name=SHELVE_FIELD,
     default_value=DEFAULT_FETCH_INTERVAL 
 )
 
 # Default last_fetch_time
 __set_default_shelve(
     shelve_name=LAST_FETCH_TIME_SHELVE,
-    field_name=SHELVE_FIELD,
     default_value=DEFAULT_LAST_FETCH_TIME 
 )
 
 # Default fetch_interval
 __set_default_shelve(
     shelve_name=CHROMA_N_RESULTS_SHELVE,
-    field_name=SHELVE_FIELD,
     default_value=DEFAULT_CHROMA_N_RESULTS 
 )

--- a/src/semantic_search_engine/mattermost/mattermost.py
+++ b/src/semantic_search_engine/mattermost/mattermost.py
@@ -2,7 +2,7 @@ from time import time, sleep
 from sched import scheduler
 import shelve
 
-from semantic_search_engine.constants import DEFAULT_LAST_FETCH_TIME, FETCH_INTERVAL_SHELVE, LAST_FETCH_TIME_SHELVE, SHELVE_FIELD, MM_PAT_SHELVE
+from semantic_search_engine.constants import DEFAULT_LAST_FETCH_TIME, FETCH_INTERVAL_SHELVE, LAST_FETCH_TIME_SHELVE, MM_PAT_SHELVE
 from semantic_search_engine.mattermost.mm_api import MattermostAPI as MMApi
 from datetime import datetime
 
@@ -12,10 +12,10 @@ class Mattermost:
         self.collection = collection
 
         with shelve.open(FETCH_INTERVAL_SHELVE) as fetch_interval:
-            self.fetch_interval_in_seconds = int(fetch_interval[SHELVE_FIELD])
+            self.fetch_interval_in_seconds = int(fetch_interval[FETCH_INTERVAL_SHELVE])
 
         with shelve.open(LAST_FETCH_TIME_SHELVE) as last_fetch_time:
-            self.last_fetch_time = int(last_fetch_time[SHELVE_FIELD])
+            self.last_fetch_time = int(last_fetch_time[LAST_FETCH_TIME_SHELVE])
     
     nextFetchScheduler = scheduler(time, sleep)
     LAST_FETCH_TIME_SHELVE = LAST_FETCH_TIME_SHELVE
@@ -178,7 +178,7 @@ class Mattermost:
         # Update last_fetch_time in shelve store
         with shelve.open(LAST_FETCH_TIME_SHELVE) as db: # handles the closing of the shelve file automatically with context manager
             # Set the last fetch time to the current time for next api call
-            db[SHELVE_FIELD] = current_time
+            db[LAST_FETCH_TIME_SHELVE] = current_time
             
         # Update global last_fetch_time
         self.last_fetch_time = current_time
@@ -243,7 +243,7 @@ class Mattermost:
 
             # Reset last_fetch_time in shelve store
             with shelve.open(LAST_FETCH_TIME_SHELVE) as last_fetch_time:
-                last_fetch_time[SHELVE_FIELD] = DEFAULT_LAST_FETCH_TIME
+                last_fetch_time[LAST_FETCH_TIME_SHELVE] = DEFAULT_LAST_FETCH_TIME
                 print('Last fetch time reset!')
         except:
             print('No Chroma Collection!')

--- a/src/semantic_search_engine/mattermost/mm_api.py
+++ b/src/semantic_search_engine/mattermost/mm_api.py
@@ -1,5 +1,5 @@
 
-from semantic_search_engine.constants import MM_USER_NAME, MM_PASSWORD, MM_PAT_SHELVE, SHELVE_FIELD, MM_API_URL_SHELVE
+from semantic_search_engine.constants import MM_USER_NAME, MM_PASSWORD, MM_PAT_SHELVE, MM_API_URL_SHELVE
 import requests
 import shelve
 
@@ -7,8 +7,8 @@ class MattermostAPI:
 
     def __init__(self):
         with shelve.open( MM_API_URL_SHELVE ) as mm_api_url_db:
-            # if mm_api_url_db.get( SHELVE_FIELD, False ):
-            self.mm_api_url = mm_api_url_db[SHELVE_FIELD]
+            # if mm_api_url_db.get( MM_API_URL_SHELVE, False ):
+            self.mm_api_url = mm_api_url_db[MM_API_URL_SHELVE]
     
     def get_user_channels(self, user_id: str, *args: [str]) -> [str]:
         """get the channel_ids for all the channels a user is a member of
@@ -88,8 +88,8 @@ class MattermostAPI:
     # authenticate a user (through the MM API)
     def __get_auth_token(self):
         with shelve.open( MM_PAT_SHELVE ) as mm_personal_access_token:
-            if mm_personal_access_token.get( SHELVE_FIELD, False ):
-                return mm_personal_access_token[SHELVE_FIELD]
+            if mm_personal_access_token.get( MM_PAT_SHELVE, False ):
+                return mm_personal_access_token[MM_PAT_SHELVE]
             else:
                 print('Warning: You\'re not using a Personal Access Token, your session might expire!')
                 return requests.post(

--- a/src/semantic_search_engine/semantic_search.py
+++ b/src/semantic_search_engine/semantic_search.py
@@ -90,6 +90,8 @@ class SemanticSearch():
         
         # Get the channels list for the user from Mattermost's API
         channels_list = MMApi().get_user_channels(user_id=user_id)
+        #TODO: (Optional) Call a function to get a list of Slack channels as well
+        # and append it to the channel_list
         
         query_result = self.collection.query(
             query_texts=[query],

--- a/src/semantic_search_engine/semantic_search.py
+++ b/src/semantic_search_engine/semantic_search.py
@@ -1,7 +1,7 @@
 from chromadb import EmbeddingFunction
 from semantic_search_engine.llm import TogetherLLM
 from semantic_search_engine.chroma import  get_chroma_collection
-from semantic_search_engine.constants import MM_API_URL_SHELVE, CHROMA_N_RESULTS_SHELVE, SHELVE_FIELD
+from semantic_search_engine.constants import MM_API_URL_SHELVE, CHROMA_N_RESULTS_SHELVE
 from langchain import LLMChain, PromptTemplate
 from chromadb.utils import embedding_functions
 from langchain.llms.base import LLM
@@ -86,7 +86,7 @@ class SemanticSearch():
         """
         # Get the number of results to be returned by Chroma from shelve
         with shelve.open(CHROMA_N_RESULTS_SHELVE) as chroma_n_results:
-            n_results = int(chroma_n_results[SHELVE_FIELD])
+            n_results = int(chroma_n_results[CHROMA_N_RESULTS_SHELVE])
         
         # Get the channels list for the user from Mattermost's API
         channels_list = MMApi().get_user_channels(user_id=user_id)
@@ -170,7 +170,7 @@ class SemanticSearch():
 
                 # Get the number of results to be returned by Chroma from shelve
                 with shelve.open(MM_API_URL_SHELVE) as mm_api_url:
-                    api_url = mm_api_url[SHELVE_FIELD]
+                    api_url = mm_api_url[MM_API_URL_SHELVE]
                 
                 # Look for "api" from the right and cut out the url after that...  "http://localhost:8065/api/v4"  -->  "http://localhost:8065/"
                 mm_url = api_url[: api_url.rfind("api") ]

--- a/src/semantic_search_engine/slack/__init__.py
+++ b/src/semantic_search_engine/slack/__init__.py
@@ -6,6 +6,6 @@ os.makedirs(TEMP_SLACK_DATA_PATH, exist_ok=True)
 
 # get or create connection with SQLite database
 db = SqliteDatabase(
-   os.path.join(SQLITE_PATH, '/slack.db'), pragmas={'journal_mode': 'wal', 'cache_size': 10000,'foreign_keys': 1}
+   SQLITE_PATH + '/slack.db', pragmas={'journal_mode': 'wal', 'cache_size': 10000,'foreign_keys': 1}
 )
 print('Path to local db:', db.database)

--- a/src/semantic_search_engine/slack/__init__.py
+++ b/src/semantic_search_engine/slack/__init__.py
@@ -1,4 +1,11 @@
 import os
-from semantic_search_engine.constants import TEMP_SLACK_DATA_PATH
+from peewee import SqliteDatabase
+from semantic_search_engine.constants import TEMP_SLACK_DATA_PATH, SQLITE_PATH
 
 os.makedirs(TEMP_SLACK_DATA_PATH, exist_ok=True)
+
+# get or create connection with SQLite database
+db = SqliteDatabase(
+   os.path.join(SQLITE_PATH, '/slack.db'), pragmas={'journal_mode': 'wal', 'cache_size': 10000,'foreign_keys': 1}
+)
+print('Path to local db:', db.database)

--- a/src/semantic_search_engine/slack/models.py
+++ b/src/semantic_search_engine/slack/models.py
@@ -1,12 +1,5 @@
-from peewee import *
-import os
-
-# TODO: get this out of here
-# get or create connection with SQLite database
-db = SqliteDatabase(
-   os.getcwd() + '/src/database/test.db', pragmas={'journal_mode': 'wal', 'cache_size': 10000,'foreign_keys': 1}
-)
-print('Path to local db:', db.database)
+from peewee import Model, CharField, TextField, IntegerField, ForeignKeyField, DateTimeField
+from . import db
 
 # Create a schema for 'User'
 class User (Model):
@@ -29,7 +22,15 @@ class Channel (Model):
    class Meta:
       database=db
       db_table='Channels'
-    
+
+# Create a schema for 'ChannelMember'
+class ChannelMember (Model):
+   channel_id=CharField( column_name='channel_id' )
+   user_ids=TextField( column_name='user_ids' )
+   no_members=IntegerField( column_name='no_members' )
+   class Meta:
+      database=db
+      db_table='ChannelMembers'
 
 # Create a schema for 'Channel'
 class Message (Model):

--- a/src/semantic_search_engine/slack/save.py
+++ b/src/semantic_search_engine/slack/save.py
@@ -1,18 +1,16 @@
-from semantic_search_engine.slack.models import *
-import json
+import os, json
 from datetime import datetime
+from semantic_search_engine.slack.models import User, Channel, ChannelMember, Message
 from semantic_search_engine.constants import TEMP_SLACK_DATA_PATH
 
 
-temp_slack_path: str = TEMP_SLACK_DATA_PATH
-
-def save_users_data():
+def save_users_data() -> None:
     """reads users' relevant info from users.json and save it to Sqlite db
     """
     # Create a User table if it doesn't exist
     User.create_table()
     
-    with open(temp_slack_path + 'users.json') as json_file:
+    with open(os.path.join(TEMP_SLACK_DATA_PATH, 'users.json')) as json_file:
         users_json = json.load(json_file) 
     users = []
     for user in users_json:
@@ -29,31 +27,61 @@ def save_users_data():
     # TODO: should update the users if they already exist
     User.bulk_create(users)
 
-def save_channels_data(public: bool = True):
-    """reads users' relevant info from users.json and save it to Sqlite db
+def save_channels_data(channel_ids: [str]) -> [dict]:
+    """reads channels' relevant info from channels.json and save it to Sqlite db
     """
-    # Create a User table if it doesn't exist
+    # Create 'Channel' and 'ChannelMember' tables if they don't exist
     Channel.create_table()
-    file_name = 'channels.json' if public else 'groups.json'
-    
-    with open(file=temp_slack_path + file_name) as json_file:
-        channels_json = json.load(json_file) 
+    ChannelMember.create_table()
 
-    channels = []
-    for channel in channels_json:
-        channel_instance = Channel(
-            channel_id=channel['id'],
-            name=channel['name'],
-            access='pub' if public else 'pri',
-            purpose=channel['purpose']['value']
-        )
-        channels.append(channel_instance)
+    file_names = ['channels.json', 'groups.json']   # Files that hold data for public and private channels
+    saved_channels = []
 
-    # TODO: should update the channels if they already exist
-    Channel.bulk_create(channels)
+    for file_name in file_names:
+        access = 'pub' if file_name == 'channels.json' else 'pri'
+        try:
+            with open(file=os.path.join(TEMP_SLACK_DATA_PATH, file_name)) as json_file:
+                channels_json = json.load(json_file) 
+        except FileNotFoundError:
+            print(f'"{ file_name }" doesn\'t exist in "{ TEMP_SLACK_DATA_PATH }"')
+            continue
+
+        channels = []
+        channel_members = []
+        for channel in channels_json:
+            # Check if the channel_id is in the list of selected channels
+            if channel['id'] not in channel_ids:
+                continue
+
+            channel_instance = Channel(
+                channel_id=channel['id'],
+                name=channel['name'],
+                access=access,
+                purpose=channel['purpose']['value']
+            )
+            channels.append(channel_instance)
+            
+            channel_member_instance = ChannelMember(
+                channel_id=channel['id'],
+                user_ids=json.dumps( channel['members'] ),
+                no_members=len( channel['members'] )
+            )
+            channel_members.append(channel_member_instance)
+
+            saved_channels.append({
+                'id': channel['id'],
+                'name': channel['name'],
+                'access': access
+            })
+
+        # TODO: should update the channels if they already exist
+        Channel.bulk_create(channels)
+        ChannelMember.bulk_create(channel_members)
+
+    return saved_channels
 
 
-def save_channel_messages(channel_id: str, collection):
+def save_channel_messages(collection, saved_channels: [dict], channel_specs: [dict]):
     """ Reads messages from a single channel file and saves the relevant info to Sqlite and Chroma.
 
     Parameters
@@ -67,65 +95,88 @@ def save_channel_messages(channel_id: str, collection):
     """
     # Create a Message table if it doesn't exist
     Message.create_table()
+
+    for channel in saved_channels:
     
-    # Get Channel details from channel_id
-    channel = Channel.select().where(Channel.channel_id==channel_id)
-    channel_folder = temp_slack_path + channel[0].name
-    access = channel[0].access
+        # Get the directory where the channel data is stored
+        channel_folder = os.path.join(TEMP_SLACK_DATA_PATH, channel['name'])
+        channel_id = channel['id']
+        spec = channel_specs[channel_id]
 
-    # Get all files in the channel's folder (each file correspond to daily messages)
-    all_files = os.listdir(channel_folder)
-    for file_name in all_files:
-        # Read the content of the file (all messages sent in that channel in one day)
-        with open(file=channel_folder + '/' + file_name) as json_file:
-            messages_json = json.load(json_file)
-
-        messages = []
-        ids = []
-        documents = []
-        metadatas = []
-
-        for message in messages_json:
-            # subtype == channel_join is a system message that tells a users has joined a channel, not really necessary
-            # Check if 'client_msg_id' and 'text' exists/aren't empty in the json file, or else return False
-            if not (message.get("client_msg_id", False) and message.get("text", False)): 
+        if spec['store_none']:  # This is shouldn't happen because the channels are already filtered in 'slack.py'
+            continue
+        elif spec['store_all']:
+            start_date = datetime.utcfromtimestamp(0).date()
+            end_date = datetime.now().date()
+        else:
+            start_date = datetime.utcfromtimestamp(float(spec['start_date']) / 1000).date()
+            end_date = datetime.utcfromtimestamp(float(spec['end_date']) / 1000).date()
+            if start_date >= end_date: 
+                print('Start date cannot be larger that end date!')
                 continue
 
-            date_time = datetime.utcfromtimestamp( float(message['ts']) )
+        # Get all files in the channel's folder (each file correspond to daily messages)
+        all_files = os.listdir(channel_folder)
+        for file_name in all_files:
 
-            message_instance = Message(
-                message_id=message['client_msg_id'],
-                user_id=message['user'],
-                channel_id=channel_id,
-                text=message['text'],
-                time=date_time
-            )
-            messages.append(message_instance)
+            # Get the date from the filename and check whether it's in the range provided
+            date_str = file_name.split('.json')[0]  # The files are stored as YYYY-mm-dd.json
+            file_date = datetime.strptime(date_str, '%Y-%m-%d').date()
 
-            ids.append(message['client_msg_id'])
-            # TODO: each message should be embedded with the name of the user and the date / time
-            documents.append(f"({date_time.date()}) { message['user_profile']['real_name'] }: { message['text'] }")
-            metadatas.append({
-                "user_id" : message['user'],
-                "channel_id" : channel_id,
-                "access" : access,
-                "source" : 'sl',
-            })
+            # Don't save the files that are out of the specified date range
+            if start_date > file_date or end_date < file_date:
+                continue
 
-        print(f'Saving channel "{ channel[0].name }" ...', end=' ')
-        # TODO: should update the messages if they already exist
-        if messages:
-            # Use insert_many with replace=True to insert new messages and update existing ones
-            # with db.atomic():
-            #     Message.insert_many(messages).on_conflict_replace().execute()
-            Message.bulk_create(messages)
+            # Read the content of the file (all messages sent in that channel in one day)
+            with open(file=channel_folder + '/' + file_name) as json_file:
+                messages_json = json.load(json_file)
 
-            # Upsert messages to chroma
-            collection.upsert(
-                ids=ids,
-                documents=documents,
-                metadatas=metadatas
-            )
-            print('Done!')
-        else: print('The channel is empty!')
+            messages = []
+            ids = []
+            documents = []
+            metadatas = []
+
+            for message in messages_json:
+                # subtype == channel_join is a system message that tells a users has joined a channel, not really necessary
+                # Check if 'client_msg_id' and 'text' exists/aren't empty in the json file, or else return False
+                if not (message.get("client_msg_id", False) and message.get("text", False)): 
+                    continue
+
+                date_time = datetime.utcfromtimestamp( float(message['ts']) )
+
+                message_instance = Message(
+                    message_id=message['client_msg_id'],
+                    user_id=message['user'],
+                    channel_id=channel_id,
+                    text=message['text'],
+                    time=date_time
+                )
+                messages.append(message_instance)
+
+                ids.append(message['client_msg_id'])
+                # Each message is embedded with the name of the user and the date / time
+                documents.append(f"({date_time.date()}) { message['user_profile']['real_name'] }: { message['text'] }")
+                metadatas.append({
+                    "user_id" : message['user'],
+                    "channel_id" : channel_id,
+                    "access" : channel['access'],
+                    "source" : 'sl',
+                })
+
+            print(f"Saving channel \"{ channel['name'] }\" ...", end=' ')
+            # TODO: should update the messages if they already exist
+            if messages:
+                # Use insert_many with replace=True to insert new messages and update existing ones
+                # with db.atomic():
+                #     Message.insert_many(messages).on_conflict_replace().execute()
+                Message.bulk_create(messages)
+
+                # Upsert messages to chroma
+                collection.upsert(
+                    ids=ids,
+                    documents=documents,
+                    metadatas=metadatas
+                )
+                print('Done!')
+            else: print('The channel is empty!')
 


### PR DESCRIPTION
This feature allows the admin to choose which portion of slack data to store in the back-end databases (Chroma and Sqlite). Just in case, private messages are also included, but they are completely disregarded in the semantic search. They can be added to the context later on after the privacy feature on slack is complete.